### PR TITLE
Key updated

### DIFF
--- a/ros_install.sh
+++ b/ros_install.sh
@@ -62,7 +62,7 @@ echo "Download the ROS keys"
 roskey=`apt-key list | grep "ROS Builder"` && true # make sure it returns true
 if [ -z "$roskey" ]; then
   echo "No ROS key, adding"
-  sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 0xB01FA116
+  sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 fi
 
 echo "Updating & upgrading all packages"


### PR DESCRIPTION
The confirmation key for downloading ROS has been changed. To remove the broken one run the command bellow
sudo apt-key del 421C365BD9FF1F717815A3895523BAEEB01FA116
https://discourse.ros.org/t/security-issue-on-ros-build-farm/9342