### PR TITLE
Update ROS GPG key in response to its recent expiration

### DIFF
--- a/ros_install.sh
+++ b/ros_install.sh
@@ -62,7 +62,8 @@ echo "Download the ROS keys"
 roskey=`apt-key list | grep "ROS Builder"` && true # make sure it returns true
 if [ -z "$roskey" ]; then
   echo "No ROS key, adding"
-  sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+  sudo apt install -y curl
+  curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 fi
 
 echo "Updating & upgrading all packages"


### PR DESCRIPTION
As referenced in https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669,
the GPG key has become invalid again.
The new method for obtaining the key is from the above website's guide.

Install curl as well as some default system installation preset does not come with it.